### PR TITLE
fixing bail-outs for non-root users in diag mode

### DIFF
--- a/cramfsck.c
+++ b/cramfsck.c
@@ -79,6 +79,7 @@ struct cramfs_super super;	/* just find the cramfs superblock once */
 static int opt_verbose = 0;	/* 1 = verbose (-v), 2+ = very verbose (-vv) */
 static int opt_continue = 0; /* 1 = continue on error for diagnositc / recovery */
 static int log_errors_continue = 0; /* number of errors we encountered */
+static int log_errors_result = FSCK_OK;
 #ifdef INCLUDE_FS_TESTS
 static int opt_extract = 0;		/* extract cramfs (-x) */
 static char *extract_dir = "/";	/* extraction directory (-x) */
@@ -136,6 +137,7 @@ static void die(int status, int syserr, const char *fmt, ...)
 	va_end(arg_ptr);
 	if (opt_continue > 0) {
 		log_errors_continue++;
+        log_errors_result |= status;
 	} else {
 		exit(status);
     }
@@ -791,7 +793,7 @@ int main(int argc, char **argv)
 	}
 
 	if (log_errors_continue > 0) {
-		exit(FSCK_UNCORRECTED);
+		exit(log_errors_result);
 	} else {
 		exit(FSCK_OK);
 	}

--- a/cramfsck.c
+++ b/cramfsck.c
@@ -790,7 +790,11 @@ int main(int argc, char **argv)
 		printf("%s: extraction with %d errors encountered\n", filename, log_errors_continue);
 	}
 
-	exit(FSCK_OK);
+	if (log_errors_continue > 0) {
+		exit(FSCK_UNCORRECTED);
+	} else {
+		exit(FSCK_OK);
+	}
 }
 
 /*


### PR DESCRIPTION
For specific efforts, recovery of more data rather than less is helpful
 - adding the `-c` option will now cause `cramfsck` to log the error and then continue processing aiding in specific recovery scenarios
 - output will indicate the number of errors identified when processing in verbose mode
 - exit codes are unchanged because I'm not sure how many people depend on those

I don't see a contributor guide and this is my first PR against your repository, so please let me know if there are any specific tests / guidelines you'd like me to follow. I've attempted to stay as close to the original coding / naming standard as possible, but welcome any feedback.